### PR TITLE
only care about TYPE_BLUETOOTH_SCO for telephony

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -889,7 +889,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
 
     private String getAudioRouteType(int type){
         switch (type){
-            case(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP):
             case(AudioDeviceInfo.TYPE_BLUETOOTH_SCO):
                 return "Bluetooth";
             case(AudioDeviceInfo.TYPE_WIRED_HEADPHONES):


### PR DESCRIPTION
This PR makes it so that getAudioDevices only cares about bluetooth devices that work with telephony.

I believe the [A2DP](https://developer.android.com/reference/android/media/AudioDeviceInfo#TYPE_BLUETOOTH_A2DP) bluetooth type is for the audio flag? It basically is always returned even with the "Calls" bluetooth setting OFF. However the [SCO](https://developer.android.com/reference/android/media/AudioDeviceInfo#TYPE_BLUETOOTH_SCO) bluetooth type is only returned when the "Calls" bluetooth setting is ON.

So the fix should only be including the SCO type as "Bluetooth".