### PR TITLE
remove duplicate @ReactMethod overload functions causing build errors  after expo 52 upgrade

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -435,11 +435,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
-    public void displayIncomingCall(String uuid, String number, String callerName) {
-        this.displayIncomingCall(uuid, number, callerName, false, null);
-    }
-
-    @ReactMethod
     public void displayIncomingCall(String uuid, String number, String callerName, boolean hasVideo) {
         this.displayIncomingCall(uuid, number, callerName, hasVideo, null);
     }
@@ -481,11 +476,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
         }
 
         conn.onAnswer();
-    }
-
-    @ReactMethod
-    public void startCall(String uuid, String number, String callerName) {
-        this.startCall(uuid, number, callerName, false, null);
     }
 
     @ReactMethod


### PR DESCRIPTION
This PR fixes the android callkeep build errors AHS was running into.

> Error: Exception in HostObject::get for prop 'RNCallKeep': com.facebook.react.internal.turbomodule.core.TurboModuleInteropUtils$ParsingException: Unable to parse @ReactMethod annotations from native module: RNCallKeep. Details: Module exports two methods to JavaScript with the same name: "startCall [Component Stack]
 

This worked previously, but after the expo 52 upgrade and the new JSI arch, the RN team is being more strict with annotated `@ReactMethods`

The fix is to only have the fully overloaded method have the `@ReactMethod` annotation 

